### PR TITLE
fix: update PROJECT file

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -10,10 +10,10 @@ repo: github.com/openmcp-project/cluster-provider-kind
 resources:
 - api:
     crdVersion: v1
-    namespaced: true
-  controller: true
+    namespaced: false
+  controller: false
   domain: kind.clusters.openmcp.cloud
-  kind: Cluster
+  kind: ProviderConfig
   path: github.com/openmcp-project/cluster-provider-kind/api/v1alpha1
   version: v1alpha1
 version: "3"

--- a/config/samples/v1alpha1_accessrequest.yaml
+++ b/config/samples/v1alpha1_accessrequest.yaml
@@ -5,4 +5,5 @@ metadata:
 spec:
   clusterRef:
     name: one
-  rules: []
+    namespace: default
+  permissions: []

--- a/config/samples/v1alpha1_cluster.yaml
+++ b/config/samples/v1alpha1_cluster.yaml
@@ -1,18 +1,24 @@
-apiVersion: kind.clusters.openmcp.cloud/v1alpha1
+apiVersion: clusters.openmcp.cloud/v1alpha1
 kind: Cluster
 metadata:
   name: one
-spec: {}
+spec:
+  profile: kind
+  tenancy: Exclusive
 ---
-apiVersion: kind.clusters.openmcp.cloud/v1alpha1
+apiVersion: clusters.openmcp.cloud/v1alpha1
 kind: Cluster
 metadata:
   name: two
-spec: {}
+spec:
+  profile: kind
+  tenancy: Exclusive
 ---
-apiVersion: kind.clusters.openmcp.cloud/v1alpha1
+apiVersion: clusters.openmcp.cloud/v1alpha1
 kind: Cluster
 metadata:
   name: three
   namespace: kube-system
-spec: {}
+spec:
+  profile: kind
+  tenancy: Exclusive

--- a/internal/controller/accessrequest_controller.go
+++ b/internal/controller/accessrequest_controller.go
@@ -100,13 +100,17 @@ func (r *AccessRequestReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return controllerutil.SetOwnerReference(ar, secret, r.Scheme)
 	})
 
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to create or update secret: %w", err)
+	}
+
 	ar.Status.Phase = clustersv1alpha1.AccessRequestGranted
 	ar.Status.SecretRef = &commonapi.ObjectReference{
 		Name:      secret.Name,
 		Namespace: secret.Namespace,
 	}
 
-	return ctrl.Result{}, err
+	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/accessrequest_controller.go
+++ b/internal/controller/accessrequest_controller.go
@@ -46,10 +46,6 @@ type AccessRequestReconciler struct {
 	Provider kind.Provider
 }
 
-// +kubebuilder:rbac:groups=kind.clusters.openmcp.cloud,resources=accessrequests,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=kind.clusters.openmcp.cloud,resources=accessrequests/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=kind.clusters.openmcp.cloud,resources=accessrequests/finalizers,verbs=update
-
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *AccessRequestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/internal/controller/accessrequest_controller.go
+++ b/internal/controller/accessrequest_controller.go
@@ -70,6 +70,7 @@ func (r *AccessRequestReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	clusterRef := types.NamespacedName{Name: ar.Spec.ClusterRef.Name, Namespace: ar.Namespace}
 	cluster := &clustersv1alpha1.Cluster{}
 	if err := r.Get(ctx, clusterRef, cluster); err != nil {
+		// TODO: report event or status condition?
 		return ctrl.Result{}, errors.Join(err, errFailedToGetReferencedCluster)
 	}
 

--- a/internal/controller/accessrequest_controller.go
+++ b/internal/controller/accessrequest_controller.go
@@ -101,7 +101,7 @@ func (r *AccessRequestReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	})
 
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to create or update secret: %w", err)
+		return ctrl.Result{}, fmt.Errorf("failed to create or update secret for access request %q/%q: %w", ar.Namespace, ar.Name, err)
 	}
 
 	ar.Status.Phase = clustersv1alpha1.AccessRequestGranted

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -51,10 +51,6 @@ type ClusterReconciler struct {
 	Provider     kind.Provider
 }
 
-// +kubebuilder:rbac:groups=kind.clusters.openmcp.cloud,resources=clusters,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=kind.clusters.openmcp.cloud,resources=clusters/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=kind.clusters.openmcp.cloud,resources=clusters/finalizers,verbs=update
-
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -43,6 +43,10 @@ var (
 	Finalizer = clustersv1alpha1.GroupVersion.Group + "/finalizer"
 )
 
+const (
+	profileKind = "kind"
+)
+
 // ClusterReconciler reconciles a Cluster object
 type ClusterReconciler struct {
 	client.Client
@@ -67,8 +71,12 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	// Always try to update the status
-	// FIXME: error handling at the end?
 	defer r.Status().Update(ctx, cluster) //nolint:errcheck
+
+	// Check if Cluster resource has the correct profile
+	if cluster.Spec.Profile != profileKind {
+		return ctrl.Result{}, fmt.Errorf("profile '%s' is not supported by kind controller", cluster.Spec.Profile)
+	}
 
 	ctx = smartrequeue.NewContext(ctx, r.RequeueStore.For(cluster))
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR

- updates the `PROJECT` file
- removes unnecessary kubebuilder markers from `AccesssRequest` and `Cluster` controllers
- introduces a check that `AccessRequest` and `Cluster` resources will solely be reconciled if `Clusters.spec.profiles` is set to "kind"
- updates the sample files to match the latest API specification from the openmcp-operator
- improves the create/update/delete logic in the `AccessRequest` controller
- improves the error handling and emitted error messages in the logs

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Improving error handling and error messages emitted in the logs
```

```feature user
Improving create/update/delete logic in `AccessRequest` controller
```

```bugfix user
Checking that `AccessRequest` and `Cluster` resources will solely be reconciled if `Clusters.spec.profiles` is set to "kind"
```
