### PR TITLE
docs(readme): improve prerequisites, deployment and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ spec:
   image: "ghcr.io/openmcp-project/images/cluster-provider-kind:<latest-version>"
 ```
 
-To run it locally, run
+### Local Development
+To run it locally, please make sure to have a running [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) cluster with kubectl context set to the kind cluster that serves as the platform cluster. You can then run the operator locally by executing:
 ```shell
 go run ./cmd/cluster-provider-kind/main.go init
 ```

--- a/README.md
+++ b/README.md
@@ -6,6 +6,27 @@
 
 A cluster provider for OpenMCP that uses [kind](https://kind.sigs.k8s.io/) to provision clusters. Ideal for local development and E2E tests.
 
+## Requirements and Setup
+
+In combination with the [openMCP Operator](https://github.com/openmcp-project/openmcp-operator), this operator can be deployed via a simple k8s resource:
+```yaml
+apiVersion: openmcp.cloud/v1alpha1
+kind: ClusterProvider
+metadata:
+  name: kind
+spec:
+  image: "ghcr.io/openmcp-project/images/cluster-provider-kind:<latest-version>"
+```
+
+To run it locally, run
+```shell
+go run ./cmd/cluster-provider-kind/main.go init
+```
+to deploy the CRDs that are required for the operator and then
+```shell
+go run ./cmd/cluster-provider-kind/main.go run
+```
+
 ## How it works
 
 In order to create new kind clusters from within a kind cluster, the Docker socket (usually `/var/run/docker.sock`) needs to be available to the `cluster-provider-kind` pod. As a prerequisite, the Docker socket of the host machine must be mounted into the nodes of the platform kind cluster. In this case, there is only a single node (`platform-control-plane`). The socket can then be mounted by the cluster-provider-kind pod using a `hostPath` volume.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Apply the CRDs from the OpenMCP operator repository [here](https://github.com/op
 go run ./cmd/cluster-provider-kind/main.go init
 ```
 
-1. **Run the operator**:
+4. **Run the operator**:
 ```shell
 go run ./cmd/cluster-provider-kind/main.go run
 ```

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ nodes:
 - role: control-plane
   extraMounts:
   - hostPath: /var/run/docker.sock
-    containerPath: /var/run/docker.sock
+    containerPath: /var/run/host-docker.sock
 ```
 
 ### Testing Docker Socket Access
@@ -164,7 +164,7 @@ spec:
   volumes:
     - name: docker
       hostPath:
-        path: /var/run/docker.sock
+        path: /var/run/host-docker.sock
         type: Socket
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR simply improves README in providing more information about prerequisites, deployment and examples how to use the cluster-provider-kind.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
Enhancing end-user documentation around prerequisites, deployment and examples
```
