### PR TITLE
fix: Fix AccessRequest reconcile bug

### DIFF
--- a/internal/controller/accessrequest_controller.go
+++ b/internal/controller/accessrequest_controller.go
@@ -77,12 +77,11 @@ func (r *AccessRequestReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	clusterRef := types.NamespacedName{Name: ar.Spec.ClusterRef.Name, Namespace: ar.Spec.ClusterRef.Namespace}
 	cluster := &clustersv1alpha1.Cluster{}
-	if err := r.Get(ctx, clusterRef, cluster); err != nil {
+	if err := r.Get(ctx, clusterRef, cluster); err != nil && !apierrors.IsNotFound(err) {
 		// TODO: report event or status condition?
 		return ctrl.Result{}, errors.Join(err, errFailedToGetReferencedCluster)
-	}
 
-	if !isClusterProviderResponsible(cluster) {
+	} else if !isClusterProviderResponsible(cluster) { // TODO: should be refactored
 		return ctrl.Result{}, fmt.Errorf("ClusterProfile '%s' is not supported by kind controller", cluster.Spec.Profile)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a bug where deleting a cluster breaks it's access request cleanup process. 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
A proper fix for this would be to refactor the code to move the cluster check inside the reconcile/handleDelete functions and do the checks there. Because a not found cluster in case if delete is valid case, but it's a problem in case of a normal reconcile. This fix is a quick work-around to unblock the delete path. Will clean it up later in a follow up. 
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixes a bug where deleting a cluster breaks it's access request cleanup process. 
```
