### PR TITLE
chore: update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,51 +1,17 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "git-submodules": {
-    "enabled": true
-  },
-  "minimumReleaseAge": "0 days",
   "extends": [
     "config:recommended",
     "config:best-practices",
     "security:openssf-scorecard",
     "helpers:pinGitHubActionDigests",
-    ":rebaseStalePrs"
+    ":rebaseStalePrs",
+    ":enableVulnerabilityAlerts"
   ],
+  "git-submodules": {
+    "enabled": true
+  },
   "postUpdateOptions": [
     "gomodTidy"
-  ],
-  "customManagers": [
-    {
-      "description": "OpenMCP component versions in hack/local-dev.sh",
-      "customType": "regex",
-      "managerFilePatterns": ["/hack/local-dev\\.sh/"],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: versioning=(?<versioning>[^\\s]+?))?\\s[A-Z_]+=\\$\\{[A-Z_]+:-(?<currentValue>[^\\}]+)\\}"
-      ]
-    }
-  ],
-  "packageRules": [
-    {
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchDepNames": [
-        "go"
-      ],
-      "matchDepTypes": [
-        "golang"
-      ],
-      "rangeStrategy": "bump"
-    },
-    {
-      "matchManagers": ["custom.regex"],
-      "groupName": "All openMCP Project Updates",
-      "groupSlug": "all-openmcp-updates",
-      "minimumReleaseAge": "0 days",
-      "rebaseWhen": "auto",
-      "automerge": true,
-      "automergeType": "pr-comment",
-      "automergeComment": "automerge all openMCP project dependencies updates"
-    }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the renovate config according to [service-provider-template](https://github.com/openmcp-project/service-provider-template/blob/main/renovate.json). We agreed that we are using this new `renovate.json` throughout the repositories.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Update renovate config according to service-provider-template
```
