### PR TITLE
feat: Add kind localhost port binding annotation to AccessRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,24 @@ In case [kind fails to load container images from the local docker store](https:
 }
 ```
 
+#### Accessing the Platform Cluster
+
+To obtain a kubeconfig for the platform cluster, the script creates an `AccessRequest` and waits for it to be granted. The resulting kubeconfig is written to a temporary file:
+
+```bash
+./hack/local-dev.sh access-platform-cluster
+```
+
+Alternatively, you can switch your current kubectl context directly to the platform cluster:
+
+```bash
+./hack/local-dev.sh access-platform-cluster --force
+```
+
+This remembers your previous context and prints a command to switch back.
+
+#### Resetting the Environment
+
 To reset your environment and delete all KinD clusters:
 
 ```bash

--- a/hack/local-dev.sh
+++ b/hack/local-dev.sh
@@ -70,7 +70,7 @@ DEPLOY_SP_GATEWAY=${DEPLOY_SP_GATEWAY:-true}
 # ============================================================================
 
 log_info() {
-  echo "[INFO] $*"
+  echo -e "[INFO] $*"
 }
 
 log_section() {
@@ -514,14 +514,21 @@ Usage: $(basename "$0") [COMMAND] [OPTIONS]
 
 Commands:
   deploy              Deploy OpenMCP local development environment
+  access-platform-cluster [OPTIONS]
+                      Get the platform cluster kubeconfig
   reset [OPTIONS]     Delete all KinD clusters
   help                Show this help message
+
+Options for access-platform-cluster:
+  --force             Switch current kubectl context to the platform cluster
 
 Options for reset:
   --force             Skip confirmation prompt when deleting clusters
 
 Examples:
   $(basename "$0") deploy              # Deploy everything
+  $(basename "$0") access-platform-cluster          # Get platform cluster kubeconfig
+  $(basename "$0") access-platform-cluster --force  # Switch current kubectl context to the platform cluster
   $(basename "$0") reset               # Delete clusters (with confirmation)
   $(basename "$0") reset --force       # Delete clusters (skip confirmation)
   $(basename "$0") help                # Show this help message
@@ -551,6 +558,32 @@ You can override default image versions by exporting environment variables:
   FLUX2_INSTALL_URL
 
 EOF
+}
+
+access_platform_cluster() {
+  if [[ "$1" == "--force" ]]; then
+    local previous_context_file="/tmp/.openmcp-previous-context"
+    local current_context
+    current_context=$(kubectl config current-context 2>/dev/null || echo "")
+
+    if [[ -n "$current_context" && "$current_context" != "kind-platform" ]]; then
+      echo "$current_context" > "$previous_context_file"
+    fi
+
+    kubectl config use-context kind-platform
+    log_info "Switched current context to 'kind-platform'"
+    if [[ -f "$previous_context_file" ]]; then
+      log_info "To switch back, run:\n\t kubectl config use-context $(cat "$previous_context_file")"
+    fi
+    return
+  fi
+
+  local kubeconfig_file
+  kubeconfig_file=$(mktemp /tmp/platform-kubeconfig-XXXXXX)
+  kind get kubeconfig --name platform > "$kubeconfig_file"
+
+  log_info "Platform kubeconfig written to:\n\t $kubeconfig_file"
+  log_info "Usage:\n\t export KUBECONFIG=$kubeconfig_file"
 }
 
 reset_clusters() {
@@ -628,6 +661,9 @@ fi
 case "$COMMAND" in
   deploy)
     deploy_environment
+    ;;
+  access-platform-cluster)
+    access_platform_cluster "$2"
     ;;
   reset)
     reset_clusters "$2"

--- a/internal/controller/accessrequest_controller.go
+++ b/internal/controller/accessrequest_controller.go
@@ -64,6 +64,8 @@ const (
 	reasonInternalError               = "InternalError"
 	reasonInvalidReference            = "InvalidReference"
 	reasonNotResponsible              = "NotResponsible"
+
+	kindLocalhostAddressAnnotation = groupName + "/localhost"
 )
 
 var (
@@ -195,33 +197,42 @@ func (r *AccessRequestReconciler) handleCreateOrUpdate(ctx context.Context, ar *
 		}
 	}
 	name := kindName(cluster)
+
+	// set kind localhost hostname mapping annotation. This is used by service providers running in debug/out of cluster mode to switch to localhost address for API server interactions
+	if err := r.setLocalhostKindAnnotation(ctx, ar, name); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	if ar.Spec.Token == nil {
 		return r.reconcileOIDCAccess(ctx, name, ar)
 	}
-	if ar.Spec.Token != nil {
-		res, err := r.tokenRefreshRequired(ctx, ar)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-		if res.RequeueAfter > 0 {
-			return res, nil
-		}
-		cl, restCfg, err := r.ClientProvider.CreateClient(name)
-		if err != nil {
-			return ctrl.Result{}, errutils.WithReason(err, reasonKindClusterInteractionError)
-		}
-		keep, requeueAfter, err := r.reconcileTokenAccess(ctx, cl, restCfg, ar)
-		if err != nil {
-			return ctrl.Result{}, errutils.WithReason(err, reasonKindClusterInteractionError)
-		}
-		if rerr := r.cleanupResources(ctx, cl, keep, managedResourcesLabels(ar)); rerr != nil {
-			return ctrl.Result{}, rerr
-		}
-		return ctrl.Result{
-			RequeueAfter: *requeueAfter,
-		}, nil
+
+	res, err := r.tokenRefreshRequired(ctx, ar)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
-	return ctrl.Result{}, nil
+
+	if res.RequeueAfter > 0 {
+		return res, nil
+	}
+
+	cl, restCfg, err := r.ClientProvider.CreateClient(name)
+	if err != nil {
+		return ctrl.Result{}, errutils.WithReason(err, reasonKindClusterInteractionError)
+	}
+
+	keep, requeueAfter, err := r.reconcileTokenAccess(ctx, cl, restCfg, ar)
+	if err != nil {
+		return ctrl.Result{}, errutils.WithReason(err, reasonKindClusterInteractionError)
+	}
+
+	if err := r.cleanupResources(ctx, cl, keep, managedResourcesLabels(ar)); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{
+		RequeueAfter: *requeueAfter,
+	}, nil
 }
 
 func (r *AccessRequestReconciler) reconcileOIDCAccess(ctx context.Context, clusterName string, ar *clustersv1alpha1.AccessRequest) (ctrl.Result, error) {
@@ -262,6 +273,26 @@ func (r *AccessRequestReconciler) reconcileOIDCAccess(ctx context.Context, clust
 	ar.Status.Phase = clustersv1alpha1.REQUEST_GRANTED
 
 	return ctrl.Result{}, nil
+}
+
+// setLocalhostKindAnnotation resolves the localhost API server URL for the cluster and writes it as an annotation on the AccessRequest.
+func (r *AccessRequestReconciler) setLocalhostKindAnnotation(ctx context.Context, ar *clustersv1alpha1.AccessRequest, clusterName string) error {
+	localhostKubeconfig, err := r.KubeConfigProvider.KubeConfig(clusterName, true)
+	if err != nil {
+		return errutils.WithReason(fmt.Errorf("failed to `get localhost kubeconfig: %w", err), reasonKindClusterInteractionError)
+	}
+
+	localRestConfig, err := clientcmd.RESTConfigFromKubeConfig([]byte(localhostKubeconfig))
+	if err != nil {
+		return errutils.WithReason(fmt.Errorf("failed to parse localhost kubeconfig: %w", err), reasonInternalError)
+	}
+
+	metav1.SetMetaDataAnnotation(&ar.ObjectMeta, kindLocalhostAddressAnnotation, localRestConfig.Host)
+	if err := r.Update(ctx, ar); err != nil {
+		return errutils.WithReason(fmt.Errorf("failed to set AccessRequest localhost annotation: %w", err), reasonKindClusterInteractionError)
+	}
+
+	return nil
 }
 
 func (r *AccessRequestReconciler) handleDelete(ctx context.Context, ar *clustersv1alpha1.AccessRequest, cluster *clustersv1alpha1.Cluster) error {

--- a/internal/controller/accessrequest_controller_test.go
+++ b/internal/controller/accessrequest_controller_test.go
@@ -401,6 +401,105 @@ func TestAccessRequestReconciler_Reconcile(t *testing.T) {
 	}
 }
 
+func TestAccessRequestReconciler_AnnotateLocalhostURL(t *testing.T) {
+	localhostHost := "https://127.0.0.1:9999"
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = clustersv1alpha1.AddToScheme(scheme)
+
+	tests := []struct {
+		name       string
+		provider   KubeConfigProvider
+		wantAnnot  string
+		wantErr    bool
+		wantReason string
+	}{
+		{
+			name:      "sets localhost annotation from provider kubeconfig",
+			provider:  configuredKubeConfigProvider{kubeconfig: minimalKubeconfig(localhostHost)},
+			wantAnnot: localhostHost,
+		},
+		{
+			name:       "provider error",
+			provider:   configuredKubeConfigProvider{err: errors.New("provider error")},
+			wantErr:    true,
+			wantReason: reasonKindClusterInteractionError,
+		},
+		{
+			name:       "invalid kubeconfig from provider",
+			provider:   configuredKubeConfigProvider{kubeconfig: "not-valid-yaml{{{{"},
+			wantErr:    true,
+			wantReason: reasonInternalError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ar := &clustersv1alpha1.AccessRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ar",
+					Namespace: "default",
+				},
+			}
+			r := &AccessRequestReconciler{
+				KubeConfigProvider: tt.provider,
+				Client: fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(ar).
+					Build(),
+			}
+			ctx := ctrl.LoggerInto(context.Background(), zap.New(zap.UseDevMode(true)))
+
+			err := r.setLocalhostKindAnnotation(ctx, ar, "test-cluster")
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				errWithReason, ok := err.(*controllerutilserrors.ErrorWithReason)
+				assert.True(t, ok)
+				assert.Equal(t, tt.wantReason, errWithReason.Reason())
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantAnnot, ar.Annotations[kindLocalhostAddressAnnotation])
+
+			// Verify the annotation was persisted
+			persisted := &clustersv1alpha1.AccessRequest{}
+			assert.NoError(t, r.Get(ctx, client.ObjectKeyFromObject(ar), persisted))
+			assert.Equal(t, tt.wantAnnot, persisted.Annotations[kindLocalhostAddressAnnotation])
+		})
+	}
+}
+
+var _ KubeConfigProvider = configuredKubeConfigProvider{}
+
+type configuredKubeConfigProvider struct {
+	kubeconfig string
+	err        error
+}
+
+func (f configuredKubeConfigProvider) KubeConfig(_ string, _ bool) (string, error) {
+	return f.kubeconfig, f.err
+}
+
+func minimalKubeconfig(host string) string {
+	return fmt.Sprintf(`apiVersion: v1
+clusters:
+- cluster:
+    server: %s
+  name: cluster
+contexts:
+- context:
+    cluster: cluster
+    user: kind
+  name: cluster
+current-context: cluster
+kind: Config
+users:
+- name: kind
+  user:
+    token: test-token
+`, host)
+}
+
 var _ ClientProvider = fakeClientProvider{}
 
 type fakeClientProvider struct {
@@ -422,7 +521,10 @@ type fakeKindConfigProvider struct{}
 
 // KubeConfig implements [kind.Provider].
 func (f fakeKindConfigProvider) KubeConfig(name string, localhost bool) (string, error) {
-	return "testkubeconfig", nil
+	if localhost {
+		return minimalKubeconfig("https://127.0.0.1:12345"), nil
+	}
+	return minimalKubeconfig("https://172.18.0.3:6443"), nil
 }
 
 func exampleRules() []rbacv1.PolicyRule {


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR modifies the Access Request Controller to annotates each AccessRequest with the actual cluster kind localhost URL. Service providers running in debug mode can read this annotation and dynamically replace the container IP with the localhost address at runtime. More details are here: https://github.com/openmcp-project/cluster-provider-kind/issues/116#issuecomment-4345105425 


It also adds a new sub command to the localdev script for convenient access.
**Which issue(s) this PR fixes**:
Fixes https://github.com/openmcp-project/cluster-provider-kind/issues/116

**Special notes for your reviewer**:
This was not tested on a MacOS with docker-desktop, but it should work with no issues.
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
AccessRequests are now annotated with the kind localhost URL.  Service providers can use this annotation to dynamically resolve localhost access.
```
