### PR TITLE
fix(local-access): upgrade version of cp-kind to v0.4.1

### DIFF
--- a/hack/local-dev.sh
+++ b/hack/local-dev.sh
@@ -15,7 +15,7 @@ OPENMCP_ENVIRONMENT=${OPENMCP_ENVIRONMENT:-debug}
 # Cluster Provider Kind
 # ============================================================================
 # renovate: datasource=github-releases depName=openmcp-project/cluster-provider-kind
-OPENMCP_CP_KIND_RELEASE_VERSION=${OPENMCP_CP_KIND_RELEASE_VERSION:-v0.4.0}
+OPENMCP_CP_KIND_RELEASE_VERSION=${OPENMCP_CP_KIND_RELEASE_VERSION:-v0.4.1}
 OPENMCP_CP_KIND_IMAGE=${OPENMCP_CP_KIND_IMAGE:-ghcr.io/openmcp-project/images/cluster-provider-kind:${OPENMCP_CP_KIND_RELEASE_VERSION}}
 
 # ============================================================================


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR bumps the version of the `local-dev.sh` for the [service provider debug guide](https://open-control-plane.io/developers/serviceprovider/debugging/) to the current latest version https://github.com/openmcp-project/cluster-provider-kind/releases/tag/v0.4.1.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
