### PR TITLE
chore: group openmcp-project/build renovate updates into one PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,7 +18,9 @@
     {
       "description": "OpenMCP component versions in hack/local-dev.sh",
       "customType": "regex",
-      "managerFilePatterns": ["/hack/local-dev\\.sh/"],
+      "managerFilePatterns": [
+        "/hack/local-dev\\.sh/"
+      ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: versioning=(?<versioning>[^\\s]+?))?\\s[A-Z_]+=\\$\\{[A-Z_]+:-(?<currentValue>[^\\}]+)\\}"
       ]
@@ -38,7 +40,9 @@
       "rangeStrategy": "bump"
     },
     {
-      "matchManagers": ["custom.regex"],
+      "matchManagers": [
+        "custom.regex"
+      ],
       "groupName": "All openMCP Project Updates",
       "groupSlug": "all-openmcp-updates",
       "minimumReleaseAge": "0 days",
@@ -46,6 +50,14 @@
       "automerge": true,
       "automergeType": "pr-comment",
       "automergeComment": "automerge all openMCP project dependencies updates"
+    },
+    {
+      "description": "Group openmcp-project/build submodule and workflow updates",
+      "matchDepNames": [
+        "hack/common",
+        "openmcp-project/build"
+      ],
+      "groupName": "openmcp-project/build"
     }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a Renovate `matchDepNames` entry that groups the `hack/common` git submodule and `openmcp-project/build` to prevent Renovate from creating two separate PRs per build update.

**Which issue(s) this PR fixes**:
https://github.com/openmcp-project/backlog/issues/563

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
